### PR TITLE
Do not check violations on removed files

### DIFF
--- a/src/pyright_diff_quality_plugin/pyright_plugin.py
+++ b/src/pyright_diff_quality_plugin/pyright_plugin.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+from os.path import exists
 
 from diff_cover.command_runner import run_command_for_code
 from diff_cover.hook import hookimpl as diff_cover_hookimpl
@@ -32,6 +33,8 @@ class PyrightViolationReporter(BaseViolationReporter):
         super(PyrightViolationReporter, self).__init__("pyright")
 
     def violations(self, src_path) -> list[Violation]:  # type: ignore
+        if not exists(src_path):
+            return []
         pyright_output = run_process_parse_json(["pyright", "--outputjson", src_path])
         return get_violations(pyright_output)
 

--- a/tests/test_diff_cover_plugin.py
+++ b/tests/test_diff_cover_plugin.py
@@ -1,4 +1,3 @@
-import json
 import os
 from unittest.mock import patch
 
@@ -10,6 +9,7 @@ from pyright_diff_quality_plugin.pyright_plugin import PyrightViolationReporter
 def test_plugin_can_load():
     main(["diff-quality", "--violations", "pyright"])
 
+
 @patch("pyright_diff_quality_plugin.pyright_plugin.exists")
 def test_given_file_does_not_exist_then_return_no_violations(mock_exists):
     mock_exists.return_value = False
@@ -18,10 +18,13 @@ def test_given_file_does_not_exist_then_return_no_violations(mock_exists):
     violations = reporter.violations("")
     assert violations == []
 
+
 @patch("pyright_diff_quality_plugin.pyright_plugin.exists")
 @patch("pyright_diff_quality_plugin.pyright_plugin.subprocess.run")
-def test_given_file_does_exist_and_test_json_used_then_return_expected_violations(mock_subprocess, mock_exists):
-    with open(os.path.join("tests", "test_data","test_json.json")) as f:
+def test_given_file_does_exist_and_test_json_used_then_return_expected_violations(
+    mock_subprocess, mock_exists
+):
+    with open(os.path.join("tests", "test_data", "test_json.json")) as f:
         mock_subprocess.return_value.stdout = f.read()
     mock_exists.return_value = True
 

--- a/tests/test_diff_cover_plugin.py
+++ b/tests/test_diff_cover_plugin.py
@@ -1,5 +1,30 @@
+import json
+import os
+from unittest.mock import patch
+
 from diff_cover.diff_quality_tool import main
+
+from pyright_diff_quality_plugin.pyright_plugin import PyrightViolationReporter
 
 
 def test_plugin_can_load():
     main(["diff-quality", "--violations", "pyright"])
+
+@patch("pyright_diff_quality_plugin.pyright_plugin.exists")
+def test_given_file_does_not_exist_then_return_no_violations(mock_exists):
+    mock_exists.return_value = False
+
+    reporter = PyrightViolationReporter()
+    violations = reporter.violations("")
+    assert violations == []
+
+@patch("pyright_diff_quality_plugin.pyright_plugin.exists")
+@patch("pyright_diff_quality_plugin.pyright_plugin.subprocess.run")
+def test_given_file_does_exist_and_test_json_used_then_return_expected_violations(mock_subprocess, mock_exists):
+    with open(os.path.join("tests", "test_data","test_json.json")) as f:
+        mock_subprocess.return_value.stdout = f.read()
+    mock_exists.return_value = True
+
+    reporter = PyrightViolationReporter()
+    violations = reporter.violations("")
+    assert len(violations) == 260


### PR DESCRIPTION
Fixes #5 

To test:
1. Clone this repo's main and `pip install -e` it
1. Run `diff-quality --violations=pyright --fail-under=100` against a repo with a removed file e.g. https://github.com/DiamondLightSource/hyperion/tree/dodal_271_move_beamline_parameters_into_dodal
2. Confirm fails with expected error
3. Switch `pyright_diff_quailty_plugin` to this branch
4. Re run `diff-quality --violations=pyright --fail-under=100` and confirm it prints an output
5. Confirm new tests test the behavior